### PR TITLE
fixes failing select ui test

### DIFF
--- a/select-element/test/html/select-element-ui.html
+++ b/select-element/test/html/select-element-ui.html
@@ -49,7 +49,7 @@
           s.value = 'notvalid';
           Platform.flush();
           Platform.endOfMicrotask(function() {
-            assert.equal(getComputedStyle(s.shadowRoot.querySelector('#container')).color, 'rgb(0, 0, 0)');
+            assert.equal(getComputedStyle(s.shadowRoot.querySelector('#container')).color, 'rgba(0, 0, 0, 0)');
             done();
           });
         });


### PR DESCRIPTION
Fixes the following failing test:

``` sh
Error: Uncaught Error: Uncaught AssertionError: expected 'rgba(0, 0, 0, 0)' to equal 'rgb(0, 0, 0)' (http://ebidel.github.io/polymer-experiments/select-element/tools/test/mocha-htmltest.js:34)
    at global.onerror (http://ebidel.github.io/polymer-experiments/select-element/node_modules/mocha/mocha.js:5622:10)
```
